### PR TITLE
Regexp to seek if and endifs comments

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -13,7 +13,8 @@ module.exports = {
 					keepClosingSlash: true,
 					minifyCSS: true,
 					removeComments: true,
-					processConditionalComments: true,
+					processConditionalComments: false,
+					ignoreCustomComments: [ /\[if.*|\[endif/ ]
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #119 

Drops processConditionalComments since it only supports proper HTML fragments (self open and closed fragments in the same comment) and adds a very basic ignoreCustomComments regexp.

Now `boilerplate-with-hero.html` correctly compiles with the closing VML tags and strips out all the other comments (although the whitespace is left there).
